### PR TITLE
Move away from javax.activation.MimetypesFileTypeMap

### DIFF
--- a/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentFile.java
+++ b/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentFile.java
@@ -6,14 +6,20 @@ import java.io.InputStream;
 
 public class WFSAttachmentFile extends WFSAttachment implements Closeable {
 
-    private InputStream file;
+    private final InputStream file;
+    private final long size;
 
-    public WFSAttachmentFile(InputStream file) {
+    public WFSAttachmentFile(InputStream file, long size) {
         this.file = file;
+        this.size = size;
     }
 
     public InputStream getFile() {
         return file;
+    }
+
+    public long getSize() {
+        return size;
     }
 
     @Override

--- a/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsHandler.java
+++ b/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsHandler.java
@@ -25,7 +25,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.oskari.log.AuditLog;
 
-import javax.activation.MimetypesFileTypeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -229,9 +228,13 @@ public class WFSAttachmentsHandler extends RestActionHandler {
     }
 
     private String getContentType(String extension) {
-        try {
-            return MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType("file." + extension);
-        } catch(Exception ignored) {
+        switch (extension) {
+        case "gpkg":
+            return "application/geopackage+sqlite3";
+        case "tif":
+            return "image/tiff";
+        case "las":
+        default:
             return "application/octet-stream";
         }
     }

--- a/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsHandler.java
+++ b/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsHandler.java
@@ -129,6 +129,7 @@ public class WFSAttachmentsHandler extends RestActionHandler {
         response.setContentType(getContentType(file.getFileExtension()));
         // attachment header
         response.addHeader("Content-Disposition", "attachment; filename=\"" + getFilename(file, language) + "\"");
+        response.setContentLengthLong(file.getSize());
         try (OutputStream out = response.getOutputStream()) {
             IOHelper.copy(file.getFile(), out);
         }
@@ -164,7 +165,7 @@ public class WFSAttachmentsHandler extends RestActionHandler {
         try {
             List<WFSAttachment> writtenFiles = new ArrayList<>(fileItems.size());
             for (FileItem f : fileItems) {
-                try (WFSAttachmentFile file = new WFSAttachmentFile(f.getInputStream())) {
+                try (WFSAttachmentFile file = new WFSAttachmentFile(f.getInputStream(), f.getSize())) {
                     String[] name = FileService.getBaseAndExtension(f.getName());
                     file.setFeatureId(name[0]);
                     file.setLayerId(layerId);

--- a/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsLayerHandler.java
+++ b/file-download/src/main/java/fi/tampere/filedl/WFSAttachmentsLayerHandler.java
@@ -5,8 +5,6 @@ import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.RestActionHandler;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.JSONHelper;
@@ -16,8 +14,6 @@ import org.oskari.log.AuditLog;
 
 @OskariActionRoute("WFSAttachmentsLayer")
 public class  WFSAttachmentsLayerHandler extends RestActionHandler {
-
-    private static final Logger LOG = LogFactory.getLogger(WFSAttachmentsLayerHandler.class);
 
     private static final String PARAM_LAYER = "layerId";
     private static final String KEY_ATTACHMENT_KEY = "attachmentKey";


### PR DESCRIPTION
Don't depend on the class maybe existing, especially with javax/jakarta chages.
In addition, include file size in `Content-Length` header for nicer download experience.