### PR TITLE
Bump versions and migrate to SearchPlugin

### DIFF
--- a/file-download/pom.xml
+++ b/file-download/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fi.tampere.oskari</groupId>
         <artifactId>tampere-parent</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>file-download</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.tampere.oskari</groupId>
     <artifactId>tampere-parent</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tampere applications</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <oskari.version>2.7.1</oskari.version>
+        <oskari.version>2.11.0-SNAPSHOT</oskari.version>
         <terrain.profile.version>1.1</terrain.profile.version>
         <java.version>1.8</java.version>
     </properties>

--- a/server-extension/pom.xml
+++ b/server-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fi.tampere.oskari</groupId>
         <artifactId>tampere-parent</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>server-extension</artifactId>

--- a/tampere-resources/pom.xml
+++ b/tampere-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tampere-parent</artifactId>
         <groupId>fi.tampere.oskari</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tampere-resources/src/main/java/flyway/tre/V1_0_7__replace_search_with_search_plugin.java
+++ b/tampere-resources/src/main/java/flyway/tre/V1_0_7__replace_search_with_search_plugin.java
@@ -1,0 +1,83 @@
+package flyway.tre;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.List;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.oskari.helpers.AppSetupHelper;
+import org.oskari.helpers.BundleHelper;
+
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.util.JSONHelper;
+
+public class V1_0_7__replace_search_with_search_plugin extends BaseJavaMigration {
+
+    private static final String SEARCH_BUNDLE_NAME = "search";
+    private static final String SEARCH_FROM_CHANNELS_BUNDLE_NAME = "search-from-channels";
+    private static final String SEARCH_PLUGIN_NAME = "Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin";
+
+    public void migrate(Context context) throws Exception {
+        Connection c = context.getConnection();
+
+        List<Long> appsetupIds = AppSetupHelper.getSetupsForUserAndDefaultType(c);
+        for (long id : appsetupIds) {
+            // Add search search plugin to mapfull if it doesn't exist
+            Bundle mapfull = AppSetupHelper.getAppBundle(c, id, "mapfull");
+            if (updateMapfullBundle(mapfull)) {
+                AppSetupHelper.updateAppBundle(c, id, mapfull);
+            }
+
+            // Remove both search and search-from-channels from appsetup bundles
+            AppSetupHelper.removeBundleFromApp(c, id, SEARCH_BUNDLE_NAME);
+            AppSetupHelper.removeBundleFromApp(c, id, SEARCH_FROM_CHANNELS_BUNDLE_NAME);
+        }
+
+        BundleHelper.unregisterBundle(c, SEARCH_BUNDLE_NAME);
+        BundleHelper.unregisterBundle(c, SEARCH_FROM_CHANNELS_BUNDLE_NAME);
+    }
+
+    private boolean updateMapfullBundle(Bundle mapfull) {
+        if (mapfull == null) {
+            return false;
+        }
+
+        JSONObject config = mapfull.getConfigJSON();
+        if (config == null) {
+            return false;
+        }
+
+        JSONArray plugins = JSONHelper.getJSONArray(config, "plugins");
+        if (plugins == null || searchPluginExists(plugins)) {
+            return false;
+        }
+
+        JSONObject searchPluginConfig = new JSONObject();
+        JSONHelper.putValue(searchPluginConfig,
+                "allowOptions", true);
+        JSONHelper.putValue(searchPluginConfig,
+                "columns", new JSONArray(Arrays.asList("selected", "name", "region", "type")));
+
+        JSONObject searchPlugin = new JSONObject();
+        JSONHelper.putValue(searchPlugin, "id", SEARCH_PLUGIN_NAME);
+        JSONHelper.putValue(searchPlugin, "config", searchPluginConfig);
+
+        plugins.put(searchPlugin);
+
+        return true;
+    }
+
+    private boolean searchPluginExists(JSONArray plugins) {
+        for (int i = 0; i < plugins.length(); i++) {
+            JSONObject plugin = JSONHelper.getJSONObject(plugins, i);
+            if (SEARCH_PLUGIN_NAME.equals(plugin.opt("id"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tampere-parent</artifactId>
         <groupId>fi.tampere.oskari</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Start using new SearchPlugin instead of search-from-channels
Bump version and Oskari version to match the frontend version containing SearchPlugin